### PR TITLE
Got both revD and revE compiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lsm303agr = { version = "0.1.1", optional = true }
 accelerometer = "0.12.0"
 
 [features]
-default = ["revE"]
+default = ["revD"]
 revD = ["lsm303dlhc"]
 revE = ["lsm303agr"]
 

--- a/src/compass/mod.rs
+++ b/src/compass/mod.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "revD")]
+#[cfg(not(feature = "revE"))]
 pub mod rev_d;
-#[cfg(feature = "revD")]
+#[cfg(not(feature = "revE"))]
 pub use self::rev_d::Compass;
 
 #[cfg(feature = "revE")]


### PR DESCRIPTION
I had just a few minutes this morning before the sun came up.
revD compiles with `cargo build`
revE compiles with `cargo build --features revE`

Hopefully this helps a little bit.

We'll need to figure out what to do with the error types.
Both compasses need to return a single error type. 
Not sure what to do with that yet.